### PR TITLE
fixed bug relating to selecting a new model after chat has begun

### DIFF
--- a/lm-compass/app/page.tsx
+++ b/lm-compass/app/page.tsx
@@ -77,16 +77,7 @@ export default function Home() {
 
   const confirmModelChange = () => {
     if (pendingModels && pendingModels.length > 0) {
-      const newlySelected = pendingModels.filter(
-        (model) => !selectedModels.includes(model)
-      );
-
-      // If there are newly selected models, use only those. Otherwise use pendingModels as-is
-      if (newlySelected.length > 0) {
-        setSelectedModels(newlySelected);
-      } else {
-        setSelectedModels(pendingModels);
-      }
+      setSelectedModels(pendingModels);
     } else {
       setSelectedModels([]);
     }


### PR DESCRIPTION
Resolves #62 

When users changed their model selection during an active chat (e.g., adding Claude Sonnet 4.5 to an existing ChatGPT 4.0 chat), the new chat would only include the newly added model instead of all selected models. This is not the intended behaviour.

**Steps to reproduce bug:**
1. Start a chat with ChatGPT 4.0 selected type something random
2. Add Claude Sonnet 4.5 to the selection
3. Confirm the model change dialog
4. **Bug:** New chat only has Claude Sonnet 4.5, ChatGPT 4.0 is removed

The problem was that we were doing some extra filtering of the selected models for some reason. I simplified the code to save the models, including the one we just added.