### PR TITLE
Make messaging prettier

### DIFF
--- a/lm-compass/app/page.tsx
+++ b/lm-compass/app/page.tsx
@@ -76,7 +76,7 @@ export default function Home() {
       if (!userLoaded) {
         return;
       }
-      
+
       if (!user) {
         setHasKey(false);
         setCheckingKey(false);
@@ -87,7 +87,7 @@ export default function Home() {
       try {
         const result = await hasApiKey();
         setHasKey(result.hasKey);
-        
+
         // If user is signed in but doesn't have a key, show settings dialog
         if (!result.hasKey) {
           setIsSettingsOpen(true);
@@ -184,8 +184,9 @@ export default function Home() {
                 </ItemMedia>
                 <ItemContent>
                   <ItemTitle>Sign in required</ItemTitle>
-                  <ItemDescription>
-                    You must be signed in to use this application. Please sign in to continue.
+                  <ItemDescription className="text-accent-foreground">
+                    You must be signed in to use this application. Please sign
+                    in to continue.
                   </ItemDescription>
                 </ItemContent>
                 <ItemActions>
@@ -219,7 +220,8 @@ export default function Home() {
                   <ItemContent>
                     <ItemTitle>API key required</ItemTitle>
                     <ItemDescription>
-                      You need to add your OpenRouter API key to use this application. Please add your key in settings.
+                      You need to add your OpenRouter API key to use this
+                      application. Please add your key in settings.
                     </ItemDescription>
                   </ItemContent>
                   <ItemActions>
@@ -248,7 +250,10 @@ export default function Home() {
           </SignedIn>
         </div>
 
-        <SettingsDialog open={isSettingsOpen} onOpenChange={handleSettingsClose} />
+        <SettingsDialog
+          open={isSettingsOpen}
+          onOpenChange={handleSettingsClose}
+        />
 
         <AlertDialog
           open={showModelChangeDialog}

--- a/lm-compass/components/ui/markdown.tsx
+++ b/lm-compass/components/ui/markdown.tsx
@@ -17,7 +17,7 @@ export type MarkdownProps = {
 }
 
 
- // Normalizes LaTeX delimiters to be compatible with remark-math
+// Normalizes LaTeX delimiters to be compatible with remark-math
 // Helper to split markdown into code/non-code segments
 function splitMarkdownByCode(text: string): { segments: string[], isCode: boolean[] } {
   const segments: string[] = [];
@@ -73,6 +73,65 @@ function extractLanguage(className?: string): string {
 }
 
 const INITIAL_COMPONENTS: Partial<Components> = {
+  p: function ParagraphComponent({ children, ...props }) {
+    return (
+      <p className="mb-4 last:mb-0" {...props}>
+        {children}
+      </p>
+    );
+  },
+  h1: function H1Component({ children, ...props }) {
+    return (
+      <h1 className="mb-4 mt-6 text-2xl font-bold first:mt-0" {...props}>
+        {children}
+      </h1>
+    );
+  },
+  h2: function H2Component({ children, ...props }) {
+    return (
+      <h2 className="mb-3 mt-5 text-xl font-semibold first:mt-0" {...props}>
+        {children}
+      </h2>
+    );
+  },
+  h3: function H3Component({ children, ...props }) {
+    return (
+      <h3 className="mb-2 mt-4 text-lg font-semibold first:mt-0" {...props}>
+        {children}
+      </h3>
+    );
+  },
+  ul: function UlComponent({ children, ...props }) {
+    return (
+      <ul className="mb-4 ml-6 list-disc last:mb-0" {...props}>
+        {children}
+      </ul>
+    );
+  },
+  ol: function OlComponent({ children, ...props }) {
+    return (
+      <ol className="mb-4 ml-6 list-decimal last:mb-0" {...props}>
+        {children}
+      </ol>
+    );
+  },
+  li: function LiComponent({ children, ...props }) {
+    return (
+      <li className="mb-1" {...props}>
+        {children}
+      </li>
+    );
+  },
+  blockquote: function BlockquoteComponent({ children, ...props }) {
+    return (
+      <blockquote
+        className="mb-4 border-l-4 border-border pl-4 italic last:mb-0"
+        {...props}
+      >
+        {children}
+      </blockquote>
+    );
+  },
   code: function CodeComponent({ className, children, ...props }) {
     const isInline =
       !props.node?.position?.start.line ||


### PR DESCRIPTION
Closes #75

### TL;DR

Added extra components to markdown renderer to render paragraphs, h1, h2, h3, lists, ordered lists, and block quotes.
Also made the Sign in description text more clear.

### Main change
| Before | After |
| ------- | ----- |
| <img width="984" height="540" alt="Screenshot 2026-01-12 at 11 53 45 PM" src="https://github.com/user-attachments/assets/7bb70c1a-5a9d-4e22-8606-3d4151457d1a" /> | <img width="1023" height="551" alt="Screenshot 2026-01-12 at 11 51 58 PM" src="https://github.com/user-attachments/assets/2937cb3c-40c2-4db3-b1c6-1c8c12e4ddba" /> |

#### Example (paragraphs)
<img width="1047" height="529" alt="Screenshot 2026-01-12 at 11 52 04 PM" src="https://github.com/user-attachments/assets/12d23dd9-1c35-4ec9-b8a5-a26ef49b0ee2" />

### Small extra change

| Before | After |
| ------- | ----- |
| <img width="838" height="90" alt="Screenshot 2026-01-13 at 12 02 40 AM" src="https://github.com/user-attachments/assets/b83f0a24-c5aa-4a6d-bedb-e4695d2b059b" /> | <img width="847" height="100" alt="Screenshot 2026-01-13 at 12 02 10 AM" src="https://github.com/user-attachments/assets/ac847949-4102-49d6-8fde-398859e31ea3" /> |