### PR TITLE
Implement rubric selection in chat

### DIFF
--- a/lm-compass/app/(app)/chat/page.tsx
+++ b/lm-compass/app/(app)/chat/page.tsx
@@ -32,6 +32,7 @@ import {
   ItemDescription,
   ItemActions,
 } from "@/components/ui/item";
+import { RubricSelector } from "@/components/ui/rubric-selector";
 
 export default function Home() {
   const { theme, toggleTheme, mounted } = useTheme();
@@ -58,6 +59,7 @@ export default function Home() {
   const lastMessageIdRef = useRef<string | null>(null);
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
   const [selectedRubric, setSelectedRubric] = useState("prompt-based");
+  const [selectedRubricId, setSelectedRubricId] = useState<string>("default");
   const [iterations, setIterations] = useState(1);
   const [showModelChangeDialog, setShowModelChangeDialog] = useState(false);
   const [pendingModels, setPendingModels] = useState<string[] | null>(null);
@@ -110,6 +112,11 @@ export default function Home() {
       }
       if (chatMetadataFromLoadedChat.iterations != null) {
         setIterations(chatMetadataFromLoadedChat.iterations);
+      }
+      if (chatMetadataFromLoadedChat.rubricId) {
+        setSelectedRubricId(chatMetadataFromLoadedChat.rubricId);
+      } else {
+        setSelectedRubricId("default");
       }
       clearChatMetadataFromLoadedChat();
     }
@@ -203,6 +210,10 @@ export default function Home() {
               value={selectedRubric}
               onChange={setSelectedRubric}
             />
+            <RubricSelector
+              value={selectedRubricId}
+              onChange={setSelectedRubricId}
+            />
             {selectedRubric === "rl4f" && (
               <IterationsSelector
                 value={iterations}
@@ -236,6 +247,12 @@ export default function Home() {
                 <span>
                   <strong className="font-medium text-foreground">Evaluation:</strong>{" "}
                   {getEvaluationMethodLabel(loadedChatDisplayInfo.evaluationMethod)}
+                </span>
+              )}
+              {loadedChatDisplayInfo.rubricTitle && (
+                <span>
+                  <strong className="font-medium text-foreground">Rubric:</strong>{" "}
+                  {loadedChatDisplayInfo.rubricTitle}
                 </span>
               )}
               {loadedChatDisplayInfo.iterations != null && loadedChatDisplayInfo.iterations > 1 && (
@@ -329,6 +346,7 @@ export default function Home() {
                 evaluationMethod={selectedRubric}
                 iterations={iterations}
                 chatId={chatId}
+                rubricId={selectedRubricId}
               />
             )}
           </SignedIn>

--- a/lm-compass/app/(app)/chat/prompt-input.tsx
+++ b/lm-compass/app/(app)/chat/prompt-input.tsx
@@ -48,6 +48,7 @@ type PromptInputComponentProps = {
   evaluationMethod: string;
   iterations: number;
   chatId: string;
+  rubricId: string;
 };
 
 export function PromptInputComponent({
@@ -60,6 +61,7 @@ export function PromptInputComponent({
   evaluationMethod,
   iterations,
   chatId,
+  rubricId,
 }: PromptInputComponentProps) {
   const [input, setInput] = useState("");
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -145,6 +147,7 @@ export function PromptInputComponent({
           evaluationMethod,
           iterations,
           chatId,
+          rubricId,
         }),
         signal: abortControllerRef.current.signal,
       });

--- a/lm-compass/app/api/chat/route.ts
+++ b/lm-compass/app/api/chat/route.ts
@@ -100,7 +100,58 @@ export async function POST(req: Request) {
       },
     });
 
-    const { messages, model, models, evaluationMethod, iterations, chatId } = await req.json();
+    const {
+      messages,
+      model,
+      models,
+      evaluationMethod,
+      iterations,
+      chatId,
+      rubricId,
+    } = await req.json();
+
+    let rubricText: string | undefined;
+    let rubricTitle: string | null = null;
+    let rubricMode: "weight-adjusted-default" | "custom" | null = null;
+
+    if (rubricId && rubricId !== "default") {
+      const { data: rubricRow, error: rubricError } = await supabase
+        .from("rubrics")
+        .select("id, rubric_title, rubric_content, mode, user_id")
+        .eq("id", rubricId)
+        .eq("user_id", userId)
+        .single();
+
+      if (rubricError || !rubricRow) {
+        return NextResponse.json(
+          {
+            error:
+              "Selected rubric not found or you don't have access to it.",
+          },
+          { status: 400 },
+        );
+      }
+
+      const content =
+        (rubricRow as { rubric_content: string | null }).rubric_content?.trim() ??
+        "";
+
+      if (!content) {
+        return NextResponse.json(
+          { error: "Selected rubric has no content." },
+          { status: 400 },
+        );
+      }
+
+      rubricText = content;
+      rubricTitle =
+        (rubricRow as { rubric_title: string | null }).rubric_title ?? null;
+      rubricMode =
+        ((rubricRow as { mode: string | null }).mode as
+          | "weight-adjusted-default"
+          | "custom"
+          | null) ?? null;
+    }
 
     // Normalize to models array - handle both single model (legacy) and multi-model cases
     let modelsToQuery: string[];
@@ -211,10 +262,14 @@ export async function POST(req: Request) {
                 evaluator = new PromptBasedEvaluator(llmClient);
               }
 
-              const evaluationResult = await evaluator.evaluate(successfulResults, {
-                userQuery,
-                iterations,
-              });
+              const evaluationResult = await evaluator.evaluate(
+                successfulResults,
+                {
+                  userQuery,
+                  iterations,
+                  ...(rubricText && { rubric: rubricText }),
+                },
+              );
 
               // Extract iteration results if this is RL4F
               let iterationResults: RL4FIterationResult[] | undefined;
@@ -339,6 +394,9 @@ export async function POST(req: Request) {
               const chatMetadata = {
                 evaluationMethod,
                 ...(iterations != null && { iterations }),
+                ...(rubricId && { rubricId }),
+                ...(rubricTitle && { rubricTitle }),
+                ...(rubricMode && { rubricMode }),
               };
               saveChat(supabase, chatId, userId, messagesToSave, undefined, chatMetadata).then((result) => {
                 if (result.success) {

--- a/lm-compass/components/ui/rubric-selector.tsx
+++ b/lm-compass/components/ui/rubric-selector.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import * as React from "react";
+import { Check, ChevronsUpDown, ListChecks } from "lucide-react";
+import { useSupabaseClient } from "@/utils/supabase/client";
+import { useUser } from "@clerk/nextjs";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+type RubricRow = {
+  id: string;
+  rubric_title: string | null;
+};
+
+type RubricSelectorProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export function RubricSelector({ value, onChange }: RubricSelectorProps) {
+  const supabase = useSupabaseClient();
+  const { user } = useUser();
+  const [rubrics, setRubrics] = React.useState<RubricRow[]>([]);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!user?.id) {
+      setRubrics([]);
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadRubrics = async () => {
+      setIsLoading(true);
+      try {
+        const { data, error } = await supabase
+          .from("rubrics")
+          .select("id, rubric_title")
+          .eq("user_id", user.id)
+          .order("created_at", { ascending: false });
+
+        if (!isMounted) return;
+
+        if (error) {
+          console.error("Failed to load rubrics:", error);
+          setRubrics([]);
+          return;
+        }
+
+        setRubrics((data || []) as RubricRow[]);
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadRubrics();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [supabase, user?.id]);
+
+  const effectiveValue = value || "default";
+  const selectedRubric =
+    effectiveValue === "default"
+      ? { id: "default", rubric_title: "Default rubric" }
+      : rubrics.find((r) => r.id === effectiveValue) ?? null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              role="combobox"
+              aria-expanded={open}
+              className="min-w-[220px] max-w-fit justify-between"
+              disabled={isLoading || !user}
+            >
+              <div className="flex items-center gap-2">
+                <ListChecks className="h-4 w-4 text-muted-foreground shrink-0" />
+                <span className="truncate">
+                  {selectedRubric?.rubric_title?.trim() ||
+                    "Select rubric"}
+                </span>
+              </div>
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Select a rubric for scoring</p>
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent className="w-auto min-w-[220px] p-0">
+        <Command>
+          <CommandInput placeholder="Search rubrics..." />
+          <CommandList>
+            <CommandEmpty>No rubrics found.</CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                value="default"
+                onSelect={() => {
+                  onChange("default");
+                  setOpen(false);
+                }}
+              >
+                <Check
+                  className={cn(
+                    "mr-2 h-4 w-4",
+                    effectiveValue === "default"
+                      ? "opacity-100"
+                      : "opacity-0",
+                  )}
+                />
+                <span>Default rubric</span>
+              </CommandItem>
+              {rubrics.map((rubric) => (
+                <CommandItem
+                  key={rubric.id}
+                  value={rubric.id}
+                  onSelect={() => {
+                    onChange(rubric.id);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      effectiveValue === rubric.id
+                        ? "opacity-100"
+                        : "opacity-0",
+                    )}
+                  />
+                  <span>
+                    {rubric.rubric_title?.trim() || "Untitled rubric"}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+

--- a/lm-compass/contexts/chat-context.tsx
+++ b/lm-compass/contexts/chat-context.tsx
@@ -66,7 +66,12 @@ type ChatContextType = {
   modelsFromLastLoadedChat: string[] | null;
   chatMetadataFromLoadedChat: ChatMetadata | null;
   /** Snapshot of models + evaluation method for display when viewing a loaded chat */
-  loadedChatDisplayInfo: { models: string[]; evaluationMethod?: string; iterations?: number } | null;
+  loadedChatDisplayInfo: {
+    models: string[];
+    evaluationMethod?: string;
+    iterations?: number;
+    rubricTitle?: string | null;
+  } | null;
   clearModelsFromLastLoadedChat: () => void;
   clearChatMetadataFromLoadedChat: () => void;
   handleNewChat: () => void;
@@ -102,6 +107,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     models: string[];
     evaluationMethod?: string;
     iterations?: number;
+    rubricTitle?: string | null;
   } | null>(null);
   const { user } = useUser();
   const supabase = useSupabaseClient();
@@ -141,6 +147,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
             models: modelsUsed,
             ...(chatMetadata?.evaluationMethod != null && { evaluationMethod: chatMetadata.evaluationMethod }),
             ...(chatMetadata?.iterations != null && { iterations: chatMetadata.iterations }),
+            ...(chatMetadata?.rubricTitle != null && { rubricTitle: chatMetadata.rubricTitle }),
           });
           // Mark that we've loaded a chat (prevents auto-loading on new chat)
           hasLoadedInitialChat.current = true;

--- a/lm-compass/lib/chat-storage.ts
+++ b/lm-compass/lib/chat-storage.ts
@@ -12,6 +12,9 @@ export type ChatHistoryItem = {
 export type ChatMetadata = {
   evaluationMethod?: string;
   iterations?: number;
+  rubricId?: string | null;
+  rubricTitle?: string | null;
+  rubricMode?: "weight-adjusted-default" | "custom" | null;
 };
 
 type DatabaseMessage = {
@@ -80,13 +83,31 @@ export async function saveChat(
       updated_at: new Date().toISOString(),
     };
 
-    if (chatMetadata && (chatMetadata.evaluationMethod != null || chatMetadata.iterations != null)) {
+    if (
+      chatMetadata &&
+      (
+        chatMetadata.evaluationMethod != null ||
+        chatMetadata.iterations != null ||
+        chatMetadata.rubricId != null ||
+        chatMetadata.rubricTitle != null ||
+        chatMetadata.rubricMode != null
+      )
+    ) {
       chatRow.metadata = {
         ...(chatMetadata.evaluationMethod != null && {
           evaluationMethod: chatMetadata.evaluationMethod,
         }),
         ...(chatMetadata.iterations != null && {
           iterations: chatMetadata.iterations,
+        }),
+        ...(chatMetadata.rubricId != null && {
+          rubricId: chatMetadata.rubricId,
+        }),
+        ...(chatMetadata.rubricTitle != null && {
+          rubricTitle: chatMetadata.rubricTitle,
+        }),
+        ...(chatMetadata.rubricMode != null && {
+          rubricMode: chatMetadata.rubricMode,
         }),
       };
     }


### PR DESCRIPTION
Closes #161

This PR will now allow users to select between default and custom rubrics for the evaluation methods.
<img width="780" height="346" alt="image" src="https://github.com/user-attachments/assets/0c41ebac-5dae-4067-b075-01e7c5a74d24" />


### Next steps:
 Currently, you can view ALL rubrics in the rubric selection. What I think would be ideal is that we add some categories to rubrics (ex. rubric is for prompt-based, RL4F, HITL). Then when we select a eval method, we should see rubrics that are for that eval method. Will do this in a followup PR
