### PR TITLE
Add time taken for each experiment and force-stop functionality

### DIFF
--- a/lm-compass/app/(app)/experiments/[id]/page.tsx
+++ b/lm-compass/app/(app)/experiments/[id]/page.tsx
@@ -129,10 +129,23 @@ function formatPercent(value: number) {
 }
 
 function formatDurationMs(value: number) {
-  if (value >= 1000) {
-    return `${(value / 1000).toFixed(2)}s`;
+  if (!Number.isFinite(value) || value < 0) return "—";
+  if (value < 1000) {
+    return `${Math.round(value)}ms`;
   }
-  return `${Math.round(value)}ms`;
+  const totalSeconds = value / 1000;
+  if (totalSeconds <= 60) {
+    return `${totalSeconds.toFixed(2)}s`;
+  }
+  const totalSecs = Math.round(totalSeconds);
+  const hours = Math.floor(totalSecs / 3600);
+  const minutes = Math.floor((totalSecs % 3600) / 60);
+  const seconds = totalSecs % 60;
+  const parts: string[] = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+  return parts.join(" ");
 }
 
 function formatModelLabel(model: string) {
@@ -357,7 +370,7 @@ export default function ExperimentDetailPage() {
   const fetchExperiment = useCallback(async (id: string, userId: string) => {
     const { data, error: fetchError } = await supabase
       .from("experiments")
-      .select("id, title, status, created_at, configuration")
+      .select("id, title, status, created_at, start_time, end_time, configuration")
       .eq("id", id)
       .eq("user_id", userId)
       .maybeSingle();
@@ -511,6 +524,19 @@ export default function ExperimentDetailPage() {
   }, [items]);
 
   const isExperimentDone = experiment?.status === ExperimentStatus.COMPLETED;
+
+  const totalRunMsAfterCompletion = useMemo(() => {
+    if (!isExperimentDone) return null;
+    if (!experiment?.start_time || !experiment?.end_time) return null;
+
+    const startMs = Date.parse(experiment.start_time);
+    const endMs = Date.parse(experiment.end_time);
+
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return null;
+
+    const delta = endMs - startMs;
+    return delta >= 0 ? delta : null;
+  }, [experiment?.start_time, experiment?.end_time, isExperimentDone]);
 
   const chartData = useMemo(() => {
     const scoreSums: Record<string, number> = {};
@@ -957,6 +983,15 @@ export default function ExperimentDetailPage() {
                 <span className="text-xs text-muted-foreground">
                   {progress.done} / {progress.total} completed
                 </span>
+
+                {isExperimentDone && (
+                  <span className="text-xs text-muted-foreground tabular-nums">
+                    Total time:{" "}
+                    {totalRunMsAfterCompletion != null
+                      ? formatDurationMs(totalRunMsAfterCompletion)
+                      : "—"}
+                  </span>
+                )}
 
                 {isExperimentDone && (
                   <Button

--- a/lm-compass/app/api/experiments/start/route.ts
+++ b/lm-compass/app/api/experiments/start/route.ts
@@ -188,7 +188,10 @@ export async function POST(req: Request) {
     } catch (error) {
       await supabase
         .from('experiments')
-        .update({ status: ExperimentStatus.ERROR })
+        .update({
+          status: ExperimentStatus.ERROR,
+          end_time: new Date().toISOString(),
+        })
         .eq('id', experiment.id);
 
       const message =
@@ -198,7 +201,10 @@ export async function POST(req: Request) {
 
     const { error: updateStatusError } = await supabase
       .from('experiments')
-      .update({ status: ExperimentStatus.RUNNING })
+      .update({
+        status: ExperimentStatus.RUNNING,
+        start_time: new Date().toISOString(),
+      })
       .eq('id', experiment.id);
 
     if (updateStatusError) {

--- a/lm-compass/contexts/experiments-context.tsx
+++ b/lm-compass/contexts/experiments-context.tsx
@@ -350,7 +350,10 @@ export function ExperimentsProvider({
               // Mark experiment as completed
               await supabase
                 .from("experiments")
-                .update({ status: ExperimentStatus.COMPLETED })
+                .update({
+                  status: ExperimentStatus.COMPLETED,
+                  end_time: new Date().toISOString(),
+                })
                 .eq("id", activeExperimentId);
 
               setActiveExperimentId(null);

--- a/lm-compass/lib/types.ts
+++ b/lm-compass/lib/types.ts
@@ -34,6 +34,8 @@ export interface Experiment {
   title: string | null;
   status: ExperimentStatus | null;
   created_at: string | null;
+  start_time: string | null;
+  end_time: string | null;
   configuration: {
     selected_models: string[];
     rubric_id: string;


### PR DESCRIPTION
Resolves #186

As the PR title suggests, we can now see how long each experiment takes and there is a force-stop button available.

Time taken displayed:
<img width="531" height="133" alt="image" src="https://github.com/user-attachments/assets/f6e90e2e-cc8d-4433-a559-b4d16a1e8a26" />

Cancel button:
<img width="1238" height="251" alt="image" src="https://github.com/user-attachments/assets/15b25fc9-8dca-49eb-8238-e0a7610342da" />


### Notes for reviewer:

I just decided to not show anything for the cancelled experiment. Let me know if this is okay or if I should still show results for queries that have completed.