### PR TITLE
Edit rubric feature

### DIFF
--- a/lm-compass/app/(app)/rubric/actions.ts
+++ b/lm-compass/app/(app)/rubric/actions.ts
@@ -16,6 +16,8 @@ type CreateRubricFromDefaultPayload = {
   mode: "weight-adjusted-default";
   title: string;
   weights: Record<string, number>;
+  categoryLabels?: Record<string, string>;
+  categoryDescriptions?: Record<string, string>;
   evaluationMethods: RubricEvaluationMethod[];
 };
 
@@ -47,7 +49,7 @@ export async function createRubric(
     let mode: "weight-adjusted-default" | "custom";
     let title: string;
     let content: string;
-    let weightsJson: Record<string, number> | null = null;
+    let weightsJson: Record<string, unknown> | null = null;
     let evaluationMethods: RubricEvaluationMethod[] = ["prompt-based"];
 
     if ("mode" in input) {
@@ -113,8 +115,18 @@ export async function createRubric(
           };
         }
 
-        weightsJson = normalizedWeights;
-        content = buildRubricFromWeights(categories, normalizedWeights);
+        const labelOverrides = input.categoryLabels ?? {};
+        const descOverrides = input.categoryDescriptions ?? {};
+
+        weightsJson = {
+          weights: normalizedWeights,
+          ...(Object.keys(labelOverrides).length > 0 ? { labels: labelOverrides } : {}),
+          ...(Object.keys(descOverrides).length > 0 ? { descriptions: descOverrides } : {}),
+        };
+        content = buildRubricFromWeights(categories, normalizedWeights, {
+          labels: labelOverrides,
+          descriptions: descOverrides,
+        });
       } else {
         mode = "custom";
         content = input.content?.trim() ?? "";
@@ -188,7 +200,7 @@ export async function updateRubric(
 
     let mode: "weight-adjusted-default" | "custom";
     let content: string;
-    let weightsJson: Record<string, number> | null = null;
+    let weightsJson: Record<string, unknown> | null = null;
     let evaluationMethods: RubricEvaluationMethod[] = ["prompt-based"];
 
     if (Array.isArray(input.evaluationMethods) && input.evaluationMethods.length > 0) {
@@ -247,8 +259,18 @@ export async function updateRubric(
         };
       }
 
-      weightsJson = normalizedWeights;
-      content = buildRubricFromWeights(categories, normalizedWeights);
+      const labelOverrides = input.categoryLabels ?? {};
+      const descOverrides = input.categoryDescriptions ?? {};
+
+      weightsJson = {
+        weights: normalizedWeights,
+        ...(Object.keys(labelOverrides).length > 0 ? { labels: labelOverrides } : {}),
+        ...(Object.keys(descOverrides).length > 0 ? { descriptions: descOverrides } : {}),
+      };
+      content = buildRubricFromWeights(categories, normalizedWeights, {
+        labels: labelOverrides,
+        descriptions: descOverrides,
+      });
     } else {
       mode = "custom";
       content = input.content?.trim() ?? "";

--- a/lm-compass/app/(app)/rubric/view/page.tsx
+++ b/lm-compass/app/(app)/rubric/view/page.tsx
@@ -43,7 +43,7 @@ type RubricRow = {
   created_at: string | null;
   category: string | null;
   mode: string | null;
-  weights_json: Record<string, number> | null;
+  weights_json: Record<string, unknown> | null;
 };
 
 function formatDate(dateString: string) {
@@ -164,6 +164,18 @@ export default function ViewRubricsPage() {
           ["prompt-based", "rl4f", "hitl"].includes(c)
         ) ?? ["prompt-based"];
 
+    const raw = editingRubric.weights_json;
+    const isStructured = raw && typeof raw === "object" && "weights" in raw;
+    const weights = isStructured
+      ? (raw as { weights: Record<string, number> }).weights
+      : (raw as Record<string, number> | null);
+    const categoryLabels = isStructured
+      ? (raw as { labels?: Record<string, string> }).labels ?? null
+      : null;
+    const categoryDescriptions = isStructured
+      ? (raw as { descriptions?: Record<string, string> }).descriptions ?? null
+      : null;
+
     return {
       mode:
         editingRubric.mode === "weight-adjusted-default"
@@ -171,7 +183,9 @@ export default function ViewRubricsPage() {
           : "custom",
       title: editingRubric.rubric_title ?? "",
       content: editingRubric.rubric_content ?? "",
-      weights: editingRubric.weights_json,
+      weights,
+      categoryLabels,
+      categoryDescriptions,
       evaluationMethods: methods.length > 0 ? methods : ["prompt-based"],
     };
   }, [editingRubric]);

--- a/lm-compass/components/add-rubric-dialog.tsx
+++ b/lm-compass/components/add-rubric-dialog.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Minus, Plus } from "lucide-react";
 import type { RubricCategory, RubricEvaluationMethod } from "@/lib/rubrics";
 import { getDefaultRubricCategories } from "@/app/(app)/rubric/actions";
 import { cn } from "@/lib/utils";
@@ -21,6 +22,8 @@ type CreateRubricFromDefaultPayload = {
   mode: "weight-adjusted-default";
   title: string;
   weights: Record<string, number>;
+  categoryLabels?: Record<string, string>;
+  categoryDescriptions?: Record<string, string>;
   evaluationMethods: RubricEvaluationMethod[];
 };
 
@@ -40,6 +43,8 @@ export interface RubricDialogInitialData {
   title: string;
   content: string;
   weights: Record<string, number> | null;
+  categoryLabels?: Record<string, string> | null;
+  categoryDescriptions?: Record<string, string> | null;
   evaluationMethods: RubricEvaluationMethod[];
 }
 
@@ -62,6 +67,8 @@ export function AddRubricDialog({ open, onOpenChange, onSave, initialData }: Add
   const [evaluationMethods, setEvaluationMethods] = useState<
     RubricEvaluationMethod[]
   >(["prompt-based"]);
+  const [categoryLabels, setCategoryLabels] = useState<Record<string, string>>({});
+  const [categoryDescriptions, setCategoryDescriptions] = useState<Record<string, string>>({});
 
   useEffect(() => {
     if (!open) {
@@ -75,6 +82,8 @@ export function AddRubricDialog({ open, onOpenChange, onSave, initialData }: Add
       setRubricName(initialData.title);
       setRubricDescription(initialData.mode === "custom" ? initialData.content : "");
       setWeights(initialData.weights ?? {});
+      setCategoryLabels(initialData.categoryLabels ?? {});
+      setCategoryDescriptions(initialData.categoryDescriptions ?? {});
       setEvaluationMethods(
         initialData.evaluationMethods.length > 0
           ? initialData.evaluationMethods
@@ -85,6 +94,8 @@ export function AddRubricDialog({ open, onOpenChange, onSave, initialData }: Add
       setRubricDescription("");
       setMode("custom");
       setWeights({});
+      setCategoryLabels({});
+      setCategoryDescriptions({});
       setEvaluationMethods(["prompt-based"]);
     }
   }, [open, initialData]);
@@ -110,6 +121,8 @@ export function AddRubricDialog({ open, onOpenChange, onSave, initialData }: Add
 
         if (initialData?.mode === "weight-adjusted-default" && initialData.weights) {
           setWeights(initialData.weights);
+          setCategoryLabels(initialData.categoryLabels ?? {});
+          setCategoryDescriptions(initialData.categoryDescriptions ?? {});
         } else {
           const defaultWeights: Record<string, number> = {};
           for (const cat of result.data) {
@@ -136,6 +149,8 @@ export function AddRubricDialog({ open, onOpenChange, onSave, initialData }: Add
     setMode("custom");
     setCategories(null);
     setWeights({});
+    setCategoryLabels({});
+    setCategoryDescriptions({});
     setCategoriesError(null);
     setEvaluationMethods(["prompt-based"]);
     onOpenChange(false);
@@ -201,10 +216,14 @@ export function AddRubricDialog({ open, onOpenChange, onSave, initialData }: Add
       });
     } else {
       if (!isDefaultModeValid) return;
+      const hasLabelOverrides = Object.keys(categoryLabels).length > 0;
+      const hasDescOverrides = Object.keys(categoryDescriptions).length > 0;
       await onSave({
         mode: "weight-adjusted-default",
         title: rubricName.trim(),
         weights,
+        ...(hasLabelOverrides ? { categoryLabels } : {}),
+        ...(hasDescOverrides ? { categoryDescriptions } : {}),
         evaluationMethods,
       });
     }
@@ -355,34 +374,94 @@ export function AddRubricDialog({ open, onOpenChange, onSave, initialData }: Add
               )}
 
               {categories && categories.length > 0 && (
-                <div className="space-y-3 max-h-64 overflow-y-auto pr-1">
-                  {categories.map((cat) => (
-                    <div key={cat.key} className="space-y-1 rounded-md border p-2">
-                      <div className="flex items-center justify-between gap-2">
-                        <div className="text-sm font-medium">{cat.key}</div>
-                        <div className="flex items-center gap-1">
+                <div className="space-y-3 max-h-72 overflow-y-auto pr-1">
+                  {categories.map((cat) => {
+                    const currentPoints = weights[cat.key] ?? cat.defaultPoints;
+                    const pointsUsedByOthers = Object.entries(weights)
+                      .filter(([k]) => k !== cat.key)
+                      .reduce((sum, [, v]) => sum + (Number.isFinite(v) ? v : 0), 0);
+                    const maxForThis = 100 - pointsUsedByOthers;
+
+                    return (
+                      <div key={cat.key} className="space-y-2 rounded-md border p-3">
+                        <div className="flex items-center justify-between gap-3">
                           <Input
-                            type="number"
-                            className="h-8 w-20"
-                            value={weights[cat.key] ?? cat.defaultPoints}
-                            onChange={(e) => {
-                              const next = Number(e.target.value);
-                              setWeights((prev) => ({
+                            className="h-8 text-sm font-medium"
+                            value={categoryLabels[cat.key] ?? cat.key}
+                            onChange={(e) =>
+                              setCategoryLabels((prev) => ({
                                 ...prev,
-                                [cat.key]: Number.isNaN(next) ? 0 : next,
-                              }));
-                            }}
+                                [cat.key]: e.target.value,
+                              }))
+                            }
+                            placeholder="Category name"
                           />
-                          <span className="text-xs text-muted-foreground">
-                            points
-                          </span>
+                          <div className="flex items-center gap-1 shrink-0">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="icon"
+                              className="h-7 w-7"
+                              disabled={currentPoints <= 0}
+                              onClick={() =>
+                                setWeights((prev) => ({
+                                  ...prev,
+                                  [cat.key]: Math.max(0, currentPoints - 1),
+                                }))
+                              }
+                            >
+                              <Minus className="h-3 w-3" />
+                            </Button>
+                            <Input
+                              type="text"
+                              inputMode="numeric"
+                              className="h-7 w-12 text-center text-sm font-medium tabular-nums px-1 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                              value={currentPoints}
+                              onChange={(e) => {
+                                const raw = e.target.value.replace(/[^0-9]/g, "");
+                                if (raw === "") {
+                                  setWeights((prev) => ({ ...prev, [cat.key]: 0 }));
+                                  return;
+                                }
+                                const next = Math.min(Number(raw), maxForThis);
+                                setWeights((prev) => ({ ...prev, [cat.key]: next }));
+                              }}
+                            />
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="icon"
+                              className="h-7 w-7"
+                              disabled={currentPoints >= maxForThis}
+                              onClick={() =>
+                                setWeights((prev) => ({
+                                  ...prev,
+                                  [cat.key]: Math.min(currentPoints + 1, maxForThis),
+                                }))
+                              }
+                            >
+                              <Plus className="h-3 w-3" />
+                            </Button>
+                            <span className="text-xs text-muted-foreground ml-0.5">
+                              pts
+                            </span>
+                          </div>
                         </div>
+                        <Textarea
+                          className="text-xs text-muted-foreground resize-none min-h-0"
+                          rows={2}
+                          value={categoryDescriptions[cat.key] ?? cat.description}
+                          onChange={(e) =>
+                            setCategoryDescriptions((prev) => ({
+                              ...prev,
+                              [cat.key]: e.target.value,
+                            }))
+                          }
+                          placeholder="Category description"
+                        />
                       </div>
-                      <p className="text-xs text-muted-foreground">
-                        {cat.description}
-                      </p>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/lm-compass/lib/rubrics.ts
+++ b/lm-compass/lib/rubrics.ts
@@ -66,7 +66,11 @@ export function parseDefaultRubric(text: string): RubricCategory[] {
 
 export function buildRubricFromWeights(
   categories: RubricCategory[],
-  weights: Record<string, number>
+  weights: Record<string, number>,
+  overrides?: {
+    labels?: Record<string, string>;
+    descriptions?: Record<string, string>;
+  }
 ): string {
   const lines: string[] = [];
 
@@ -76,8 +80,11 @@ export function buildRubricFromWeights(
         ? weights[category.key]
         : category.defaultPoints;
 
+    const label = overrides?.labels?.[category.key] || category.key;
+    const description = overrides?.descriptions?.[category.key] || category.description;
+
     lines.push(
-      `${category.key} (${points} points) — ${category.description}`
+      `${label} (${points} points) — ${description}`
     );
 
     if (index < categories.length - 1) {


### PR DESCRIPTION
Addresses #187 

Adds an Edit button to the View Rubrics page so users can modify and save existing rubrics. For weight-adjusted-default rubrics, category names, descriptions, and point weights are all editable. Points use +/- stepper buttons with a direct-entry field, capped at 100 total.

File changes
- app/(app)/rubric/actions.ts -- New updateRubric server action; extended payload to support category label/description overrides.
- app/(app)/rubric/view/page.tsx -- Edit button, edit dialog wiring, expanded data fetching for mode/weights_json.
components/add-rubric-dialog.tsx -- Edit mode support via initialData prop; editable category names/descriptions; +/- stepper with 100pt cap.
- lib/rubrics.ts -- buildRubricFromWeights accepts optional label/description overrides.