### PR TITLE
Adding front end testing to LM Compass

### DIFF
--- a/lm-compass/app/(app)/chat/prompt-input.test.tsx
+++ b/lm-compass/app/(app)/chat/prompt-input.test.tsx
@@ -1,0 +1,705 @@
+import { describe, expect, it, vi, beforeEach, type Mock } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PromptInputComponent } from "./prompt-input";
+import type { Message } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockStreamResponse(
+  chunks: Record<string, unknown>[],
+  options: { ok?: boolean; status?: number; statusText?: string } = {}
+) {
+  const { ok = true, status = 200, statusText = "OK" } = options;
+  const encoded = chunks.map((c) => `data: ${JSON.stringify(c)}\n`).join("");
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(encoded));
+      controller.close();
+    },
+  });
+  return {
+    ok,
+    status,
+    statusText,
+    body: stream,
+    json: () => Promise.resolve({}),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+function createErrorResponse(
+  status: number,
+  body: Record<string, unknown> | null,
+  statusText = ""
+) {
+  return {
+    ok: false,
+    status,
+    statusText,
+    body: null,
+    json: body ? () => Promise.resolve(body) : () => Promise.reject(new Error("no json")),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+const VALID_COMPLETE_CHUNK = {
+  phase: "complete",
+  results: [
+    { model: "model-a", message: { role: "assistant", content: "response a" } },
+    { model: "model-b", message: { role: "assistant", content: "response b" } },
+  ],
+  evaluationMetadata: {
+    winnerModel: "model-a",
+    scores: [],
+    meanScores: {},
+    modelReasoning: {},
+    tiedModels: [],
+  },
+};
+
+const defaultProps = () => ({
+  messages: [] as Message[],
+  setMessages: vi.fn(),
+  isLoading: false,
+  setIsLoading: vi.fn(),
+  setLoadingPhase: vi.fn(),
+  selectedModels: ["model-a", "model-b"],
+  evaluationMethod: "prompt-based",
+  iterations: 1,
+  chatId: "chat-1",
+  rubricId: "rubric-1",
+});
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let uuidCounter: number;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  uuidCounter = 0;
+  vi.spyOn(crypto, "randomUUID").mockImplementation(
+    () => `uuid-${uuidCounter++}` as ReturnType<typeof crypto.randomUUID>
+  );
+  vi.spyOn(global, "fetch").mockResolvedValue(
+    createMockStreamResponse([VALID_COMPLETE_CHUNK])
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Helpers to interact with the component
+// ---------------------------------------------------------------------------
+
+async function typeAndSubmit(text: string) {
+  const textarea = screen.getByRole("textbox");
+  await userEvent.type(textarea, text);
+  const button = screen.getByRole("button");
+  await userEvent.click(button);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PromptInputComponent", () => {
+  // =========================================================================
+  // Validation / guard rails
+  // =========================================================================
+  describe("input validation prevents invalid submissions", () => {
+    it("does not submit when input is empty", async () => {
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      const button = screen.getByRole("button");
+      await userEvent.click(button);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(props.setMessages).not.toHaveBeenCalled();
+    });
+
+    it("does not submit when isLoading is true", async () => {
+      const props = defaultProps();
+      props.isLoading = true;
+      render(<PromptInputComponent {...props} />);
+
+      // Textarea is disabled when loading, so we can't type — just verify button click triggers stop, not submit
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("does not submit when needsWinnerSelection is true", async () => {
+      const props = defaultProps();
+      props.messages = [
+        {
+          id: "msg-1",
+          role: "assistant",
+          content: "",
+          evaluationMetadata: {
+            winnerModel: null,
+            scores: [],
+            meanScores: {},
+            modelReasoning: {},
+            tiedModels: ["model-a", "model-b"],
+          },
+          multiResults: [
+            { model: "model-a", content: "a" },
+            { model: "model-b", content: "b" },
+          ],
+        },
+      ];
+      render(<PromptInputComponent {...props} />);
+
+      // Input should be disabled — the button should also be disabled
+      const button = screen.getByRole("button");
+      expect(button).toBeDisabled();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("does not submit when selectedModels is empty", async () => {
+      const props = defaultProps();
+      props.selectedModels = [];
+      render(<PromptInputComponent {...props} />);
+
+      const button = screen.getByRole("button");
+      expect(button).toBeDisabled();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("does not submit when HITL evaluation has fewer than 3 models", async () => {
+      const props = defaultProps();
+      props.evaluationMethod = "hitl";
+      props.selectedModels = ["model-a", "model-b"];
+      render(<PromptInputComponent {...props} />);
+
+      const button = screen.getByRole("button");
+      expect(button).toBeDisabled();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("submits successfully when all conditions are met", async () => {
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("Hello world");
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+      expect(props.setIsLoading).toHaveBeenCalledWith(true);
+    });
+  });
+
+  // =========================================================================
+  // API call correctness
+  // =========================================================================
+  describe("valid submissions trigger API calls with correct data", () => {
+    it("calls fetch with correct URL, method, and body", async () => {
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("Test query");
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      const [url, options] = (global.fetch as Mock).mock.calls[0];
+      expect(url).toBe("/api/chat");
+      expect(options.method).toBe("POST");
+
+      const body = JSON.parse(options.body);
+      expect(body.models).toEqual(["model-a", "model-b"]);
+      expect(body.evaluationMethod).toBe("prompt-based");
+      expect(body.iterations).toBe(1);
+      expect(body.chatId).toBe("chat-1");
+      expect(body.rubricId).toBe("rubric-1");
+      expect(body.messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ role: "user", content: "Test query" }),
+        ])
+      );
+    });
+
+    it("filters out isStopped messages from API payload", async () => {
+      const props = defaultProps();
+      props.messages = [
+        { id: "m1", role: "user", content: "old", isStopped: true },
+        { id: "m2", role: "user", content: "kept" },
+      ];
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("new");
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      const body = JSON.parse((global.fetch as Mock).mock.calls[0][1].body);
+      const contents = body.messages.map((m: { content: string }) => m.content);
+      expect(contents).not.toContain("old");
+      expect(contents).toContain("kept");
+      expect(contents).toContain("new");
+    });
+
+    it("filters out empty-content assistant messages in tie scenarios", async () => {
+      const props = defaultProps();
+      props.messages = [
+        { id: "m1", role: "user", content: "hello" },
+        {
+          id: "m2",
+          role: "assistant",
+          content: "",
+          evaluationMetadata: {
+            winnerModel: null,
+            scores: [],
+            meanScores: {},
+            modelReasoning: {},
+            tiedModels: ["model-a", "model-b"],
+          },
+          multiResults: [
+            { model: "model-a", content: "a" },
+            { model: "model-b", content: "b" },
+          ],
+          userSelectedWinner: "model-a",
+        },
+      ];
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("follow up");
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      const body = JSON.parse((global.fetch as Mock).mock.calls[0][1].body);
+      const assistantMessages = body.messages.filter(
+        (m: { role: string }) => m.role === "assistant"
+      );
+      // The empty-content tie assistant message should be filtered out
+      expect(assistantMessages).toHaveLength(0);
+    });
+  });
+
+  // =========================================================================
+  // HTTP error handling
+  // =========================================================================
+  describe("API error conditions are handled with user-friendly messages", () => {
+    it("handles 401 response with Unauthorized message", async () => {
+      (global.fetch as Mock).mockResolvedValueOnce(
+        createErrorResponse(401, { error: "Auth failed" })
+      );
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        expect(props.setMessages).toHaveBeenCalled();
+      });
+
+      // Find the call that appends the error message (updater function)
+      const calls = props.setMessages.mock.calls;
+      const lastUpdater = calls[calls.length - 1][0];
+      const result = lastUpdater([]);
+      expect(result[0].content).toContain("Unauthorized");
+    });
+
+    it("handles 404 response with API key not found message", async () => {
+      (global.fetch as Mock).mockResolvedValueOnce(
+        createErrorResponse(404, { error: "Not found" })
+      );
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        const calls = props.setMessages.mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const calls = props.setMessages.mock.calls;
+      const lastUpdater = calls[calls.length - 1][0];
+      const result = lastUpdater([]);
+      expect(result[0].content).toContain("API key not found");
+    });
+
+    it("handles 500 response with server error message", async () => {
+      (global.fetch as Mock).mockResolvedValueOnce(
+        createErrorResponse(500, { error: "Internal failure" })
+      );
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        const calls = props.setMessages.mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const calls = props.setMessages.mock.calls;
+      const lastUpdater = calls[calls.length - 1][0];
+      const result = lastUpdater([]);
+      expect(result[0].content).toBe("Internal failure");
+    });
+
+    it("falls back to statusText when JSON parsing fails", async () => {
+      (global.fetch as Mock).mockResolvedValueOnce(
+        createErrorResponse(502, null, "Bad Gateway")
+      );
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        const calls = props.setMessages.mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const calls = props.setMessages.mock.calls;
+      const lastUpdater = calls[calls.length - 1][0];
+      const result = lastUpdater([]);
+      expect(result[0].content).toBe("Bad Gateway");
+    });
+  });
+
+  // =========================================================================
+  // Streaming response handling
+  // =========================================================================
+  describe("streaming response handling displays content as it arrives", () => {
+    it("updates loading phase to evaluating when stream emits evaluating phase", async () => {
+      (global.fetch as Mock).mockResolvedValueOnce(
+        createMockStreamResponse([
+          { phase: "evaluating" },
+          VALID_COMPLETE_CHUNK,
+        ])
+      );
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        expect(props.setLoadingPhase).toHaveBeenCalledWith("evaluating");
+      });
+    });
+
+    it("updates loading phase to refining when stream emits refining phase", async () => {
+      (global.fetch as Mock).mockResolvedValueOnce(
+        createMockStreamResponse([
+          { phase: "evaluating" },
+          { phase: "refining" },
+          VALID_COMPLETE_CHUNK,
+        ])
+      );
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        expect(props.setLoadingPhase).toHaveBeenCalledWith("refining");
+      });
+    });
+
+    it("constructs assistant message with multiResults and evaluationMetadata on complete", async () => {
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        const calls = props.setMessages.mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const calls = props.setMessages.mock.calls;
+      const lastUpdater = calls[calls.length - 1][0];
+      const result = lastUpdater([]);
+      const assistantMsg = result[0];
+      expect(assistantMsg.role).toBe("assistant");
+      expect(assistantMsg.multiResults).toHaveLength(2);
+      expect(assistantMsg.evaluationMetadata).toBeDefined();
+      expect(assistantMsg.evaluationMetadata.winnerModel).toBe("model-a");
+    });
+
+    it("sets assistant content to winner response when winnerModel exists", async () => {
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        const calls = props.setMessages.mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const calls = props.setMessages.mock.calls;
+      const lastUpdater = calls[calls.length - 1][0];
+      const result = lastUpdater([]);
+      expect(result[0].content).toBe("response a");
+    });
+
+    it("sets assistant content to empty string on tie (no winner)", async () => {
+      const tieChunk = {
+        ...VALID_COMPLETE_CHUNK,
+        evaluationMetadata: {
+          ...VALID_COMPLETE_CHUNK.evaluationMetadata,
+          winnerModel: null,
+        },
+      };
+      (global.fetch as Mock).mockResolvedValueOnce(
+        createMockStreamResponse([tieChunk])
+      );
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        const calls = props.setMessages.mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const calls = props.setMessages.mock.calls;
+      const lastUpdater = calls[calls.length - 1][0];
+      const result = lastUpdater([]);
+      expect(result[0].content).toBe("");
+    });
+
+    it("appends error message when stream emits error phase", async () => {
+      (global.fetch as Mock).mockResolvedValueOnce(
+        createMockStreamResponse([{ phase: "error", error: "Model overloaded" }])
+      );
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        const calls = props.setMessages.mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      // The inner try/catch catches the thrown error and re-throws as
+      // "Failed to parse server response" because the line contains '"phase":"error"'
+      const calls = props.setMessages.mock.calls;
+      const lastUpdater = calls[calls.length - 1][0];
+      const result = lastUpdater([]);
+      expect(result[0].role).toBe("assistant");
+      expect(result[0].content).toBe("Failed to parse server response");
+    });
+
+    it("appends error when stream ends without a complete phase", async () => {
+      (global.fetch as Mock).mockResolvedValueOnce(
+        createMockStreamResponse([{ phase: "evaluating" }])
+      );
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        const calls = props.setMessages.mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const calls = props.setMessages.mock.calls;
+      const lastUpdater = calls[calls.length - 1][0];
+      const result = lastUpdater([]);
+      expect(result[0].content).toBe("No data received");
+    });
+
+    it("appends error when results is missing from complete payload", async () => {
+      (global.fetch as Mock).mockResolvedValueOnce(
+        createMockStreamResponse([{ phase: "complete" }])
+      );
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        const calls = props.setMessages.mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const calls = props.setMessages.mock.calls;
+      const lastUpdater = calls[calls.length - 1][0];
+      const result = lastUpdater([]);
+      expect(result[0].content).toBe("Invalid response format");
+    });
+
+    it("appends error when response.body is null", async () => {
+      (global.fetch as Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: null,
+        headers: new Headers(),
+      } as unknown as Response);
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        const calls = props.setMessages.mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const calls = props.setMessages.mock.calls;
+      const lastUpdater = calls[calls.length - 1][0];
+      const result = lastUpdater([]);
+      expect(result[0].content).toBe("No response body");
+    });
+  });
+
+  // =========================================================================
+  // Request cancellation
+  // =========================================================================
+  describe("request cancellation manages loading states properly", () => {
+    it("handleStop resets loading state and loading phase", async () => {
+      const props = defaultProps();
+      props.isLoading = true;
+      render(<PromptInputComponent {...props} />);
+
+      // When isLoading is true, the button triggers handleStop
+      const stopButton = screen.getByRole("button");
+      await userEvent.click(stopButton);
+
+      expect(props.setIsLoading).toHaveBeenCalledWith(false);
+      expect(props.setLoadingPhase).toHaveBeenCalledWith("querying");
+    });
+
+    it("handleStop marks the last user message as isStopped", async () => {
+      const props = defaultProps();
+      props.isLoading = true;
+      render(<PromptInputComponent {...props} />);
+
+      const button = screen.getByRole("button");
+      await userEvent.click(button);
+
+      expect(props.setMessages).toHaveBeenCalled();
+      const updater = props.setMessages.mock.calls[0][0];
+      const userMsg: Message = { id: "u1", role: "user", content: "hello" };
+      const result = updater([userMsg]);
+      expect(result[0].isStopped).toBe(true);
+    });
+
+    it("aborted requests do not append error messages", async () => {
+      const abortError = new Error("The operation was aborted.");
+      abortError.name = "AbortError";
+      (global.fetch as Mock).mockRejectedValueOnce(abortError);
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      // Wait a tick for the catch block to run
+      await waitFor(() => {
+        expect(props.setIsLoading).toHaveBeenCalledWith(false);
+      });
+
+      // setMessages should only have been called once (for the user message), not for an error
+      const calls = props.setMessages.mock.calls;
+      expect(calls).toHaveLength(1);
+    });
+  });
+
+  // =========================================================================
+  // Loading state lifecycle
+  // =========================================================================
+  describe("loading states are properly managed throughout the request lifecycle", () => {
+    it("sets isLoading true and loadingPhase querying on submit", async () => {
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      expect(props.setIsLoading).toHaveBeenCalledWith(true);
+      expect(props.setLoadingPhase).toHaveBeenCalledWith("querying");
+    });
+
+    it("resets isLoading and loadingPhase in finally block on success", async () => {
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        expect(props.setIsLoading).toHaveBeenCalledWith(false);
+      });
+
+      const phaseCalls = props.setLoadingPhase.mock.calls.map(
+        (c: [string]) => c[0]
+      );
+      expect(phaseCalls[0]).toBe("querying");
+      expect(phaseCalls[phaseCalls.length - 1]).toBe("querying");
+    });
+
+    it("resets isLoading and loadingPhase in finally block on error", async () => {
+      (global.fetch as Mock).mockRejectedValueOnce(new Error("Network fail"));
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      await typeAndSubmit("test");
+
+      await waitFor(() => {
+        expect(props.setIsLoading).toHaveBeenCalledWith(false);
+      });
+
+      const phaseCalls = props.setLoadingPhase.mock.calls.map(
+        (c: [string]) => c[0]
+      );
+      expect(phaseCalls[phaseCalls.length - 1]).toBe("querying");
+    });
+  });
+
+  // =========================================================================
+  // UI rendering
+  // =========================================================================
+  describe("UI rendering", () => {
+    it("shows no-models banner when selectedModels is empty", () => {
+      const props = defaultProps();
+      props.selectedModels = [];
+      render(<PromptInputComponent {...props} />);
+
+      expect(
+        screen.getByText(/please select at least one model/i)
+      ).toBeInTheDocument();
+    });
+
+    it("shows HITL banner when evaluation method is hitl with < 3 models", () => {
+      const props = defaultProps();
+      props.evaluationMethod = "hitl";
+      props.selectedModels = ["model-a", "model-b"];
+      render(<PromptInputComponent {...props} />);
+
+      expect(
+        screen.getByText(/human-in-the-loop evaluation requires at least 3 models/i)
+      ).toBeInTheDocument();
+    });
+
+    it("disables send button when no input is provided", () => {
+      const props = defaultProps();
+      render(<PromptInputComponent {...props} />);
+
+      const button = screen.getByRole("button");
+      expect(button).toBeDisabled();
+    });
+
+    it("shows stop icon when isLoading is true", () => {
+      const props = defaultProps();
+      props.isLoading = true;
+      render(<PromptInputComponent {...props} />);
+
+      const button = screen.getByRole("button");
+      expect(button).not.toBeDisabled();
+    });
+  });
+});

--- a/lm-compass/components/ui/settings-dialog.test.tsx
+++ b/lm-compass/components/ui/settings-dialog.test.tsx
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SettingsDialog } from "./settings-dialog";
+import { saveOpenRouterKey } from "@/app/(app)/settings/actions";
+
+vi.mock("@/app/(app)/settings/actions", () => ({
+  saveOpenRouterKey: vi.fn(),
+}));
+
+const mockedSave = vi.mocked(saveOpenRouterKey);
+
+const VALID_KEY = "sk-or-v1-" + "a".repeat(64);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedSave.mockResolvedValue({ success: true });
+});
+
+function renderDialog(overrides: { open?: boolean; onOpenChange?: (v: boolean) => void } = {}) {
+  const onOpenChange = overrides.onOpenChange ?? vi.fn();
+  render(
+    <SettingsDialog open={overrides.open ?? true} onOpenChange={onOpenChange} />
+  );
+  return { onOpenChange };
+}
+
+function getSaveButton() {
+  return screen.getByRole("button", { name: /save key/i });
+}
+
+function getCancelButton() {
+  return screen.getByRole("button", { name: /cancel/i });
+}
+
+function getInput() {
+  return screen.getByPlaceholderText("sk-or-v1-...");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SettingsDialog", () => {
+  // =========================================================================
+  // API key format validation
+  // =========================================================================
+  describe("invalid API key formats are detected and appropriate error messages are displayed", () => {
+    it("disables Save Key button when input is empty", () => {
+      renderDialog();
+      expect(getSaveButton()).toBeDisabled();
+    });
+
+    it("shows validation error for key missing sk-or-v1- prefix", async () => {
+      renderDialog();
+      await userEvent.type(getInput(), "invalid-key-format");
+      await userEvent.click(getSaveButton());
+
+      expect(screen.getByText(/invalid api key format/i)).toBeInTheDocument();
+      expect(mockedSave).not.toHaveBeenCalled();
+    });
+
+    it("shows validation error for key with correct prefix but wrong length", async () => {
+      renderDialog();
+      await userEvent.type(getInput(), "sk-or-v1-abc");
+      await userEvent.click(getSaveButton());
+
+      expect(screen.getByText(/invalid api key format/i)).toBeInTheDocument();
+      expect(mockedSave).not.toHaveBeenCalled();
+    });
+
+    it("shows validation error for key with special characters in 64-char portion", async () => {
+      const keyWithSpecial = "sk-or-v1-" + "a".repeat(60) + "!@#$";
+      renderDialog();
+      await userEvent.type(getInput(), keyWithSpecial);
+      await userEvent.click(getSaveButton());
+
+      expect(screen.getByText(/invalid api key format/i)).toBeInTheDocument();
+      expect(mockedSave).not.toHaveBeenCalled();
+    });
+
+    it("accepts valid key format and calls saveOpenRouterKey", async () => {
+      renderDialog();
+      await userEvent.type(getInput(), VALID_KEY);
+      await userEvent.click(getSaveButton());
+
+      await waitFor(() => {
+        expect(mockedSave).toHaveBeenCalledWith(VALID_KEY);
+      });
+    });
+
+    it("does NOT call saveOpenRouterKey when validation fails", async () => {
+      renderDialog();
+      await userEvent.type(getInput(), "bad");
+      await userEvent.click(getSaveButton());
+
+      expect(mockedSave).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Successful save flow
+  // =========================================================================
+  describe("valid submissions trigger save operations correctly with proper UI feedback", () => {
+    it("calls onOpenChange(false) to close the dialog on success", async () => {
+      const { onOpenChange } = renderDialog();
+      await userEvent.type(getInput(), VALID_KEY);
+      await userEvent.click(getSaveButton());
+
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it("clears the key input after successful save", async () => {
+      renderDialog();
+      await userEvent.type(getInput(), VALID_KEY);
+      await userEvent.click(getSaveButton());
+
+      await waitFor(() => {
+        expect(getInput()).toHaveValue("");
+      });
+    });
+  });
+
+  // =========================================================================
+  // Failed save flow
+  // =========================================================================
+  describe("failure scenarios are handled appropriately with proper UI feedback", () => {
+    it("displays server error message from result.error", async () => {
+      mockedSave.mockResolvedValueOnce({ success: false, error: "Encryption failed" });
+      renderDialog();
+      await userEvent.type(getInput(), VALID_KEY);
+      await userEvent.click(getSaveButton());
+
+      await waitFor(() => {
+        expect(screen.getByText("Encryption failed")).toBeInTheDocument();
+      });
+    });
+
+    it("displays fallback error when result.error is undefined", async () => {
+      mockedSave.mockResolvedValueOnce({ success: false } as { success: false; error: string });
+      renderDialog();
+      await userEvent.type(getInput(), VALID_KEY);
+      await userEvent.click(getSaveButton());
+
+      await waitFor(() => {
+        expect(screen.getByText("Failed to save API key")).toBeInTheDocument();
+      });
+    });
+
+    it("dialog remains open on failure", async () => {
+      mockedSave.mockResolvedValueOnce({ success: false, error: "DB down" });
+      const { onOpenChange } = renderDialog();
+      await userEvent.type(getInput(), VALID_KEY);
+      await userEvent.click(getSaveButton());
+
+      await waitFor(() => {
+        expect(screen.getByText("DB down")).toBeInTheDocument();
+      });
+      // onOpenChange should NOT have been called with false for closing
+      const closeCalls = (onOpenChange as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (c: [boolean]) => c[0] === false
+      );
+      expect(closeCalls).toHaveLength(0);
+    });
+  });
+
+  // =========================================================================
+  // Loading states
+  // =========================================================================
+  describe("loading states are managed correctly", () => {
+    it("shows Saving... on the save button while loading", async () => {
+      let resolvePromise!: (v: { success: boolean }) => void;
+      mockedSave.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolvePromise = resolve;
+        })
+      );
+      renderDialog();
+      await userEvent.type(getInput(), VALID_KEY);
+      await userEvent.click(getSaveButton());
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /saving/i })).toBeInTheDocument();
+      });
+
+      // Resolve to clean up
+      resolvePromise({ success: true });
+    });
+
+    it("disables the input field while loading", async () => {
+      let resolvePromise!: (v: { success: boolean }) => void;
+      mockedSave.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolvePromise = resolve;
+        })
+      );
+      renderDialog();
+      await userEvent.type(getInput(), VALID_KEY);
+      await userEvent.click(getSaveButton());
+
+      await waitFor(() => {
+        expect(getInput()).toBeDisabled();
+      });
+
+      resolvePromise({ success: true });
+    });
+
+    it("disables both Cancel and Save buttons while loading", async () => {
+      let resolvePromise!: (v: { success: boolean }) => void;
+      mockedSave.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolvePromise = resolve;
+        })
+      );
+      renderDialog();
+      await userEvent.type(getInput(), VALID_KEY);
+      await userEvent.click(getSaveButton());
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /saving/i })).toBeDisabled();
+      });
+      expect(getCancelButton()).toBeDisabled();
+
+      resolvePromise({ success: true });
+    });
+  });
+
+  // =========================================================================
+  // Error clearing
+  // =========================================================================
+  describe("input clearing behaviours", () => {
+    it("typing in the input clears a previously displayed error", async () => {
+      renderDialog();
+      await userEvent.type(getInput(), "bad");
+      await userEvent.click(getSaveButton());
+
+      expect(screen.getByText(/invalid api key format/i)).toBeInTheDocument();
+
+      await userEvent.type(getInput(), "x");
+
+      expect(screen.queryByText(/invalid api key format/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Form state on close
+  // =========================================================================
+  describe("form state is managed correctly on close", () => {
+    it("closing the dialog clears key and error state", async () => {
+      renderDialog();
+
+      await userEvent.type(getInput(), "bad");
+      await userEvent.click(getSaveButton());
+      expect(screen.getByText(/invalid api key format/i)).toBeInTheDocument();
+
+      await userEvent.click(getCancelButton());
+
+      await waitFor(() => {
+        expect(getInput()).toHaveValue("");
+      });
+      expect(screen.queryByText(/invalid api key format/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/lm-compass/package-lock.json
+++ b/lm-compass/package-lock.json
@@ -53,6 +53,7 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/papaparse": "^5.5.2",
         "@types/react": "^19",
@@ -64,6 +65,7 @@
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5",
+        "vite": "^6.4.1",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.2.4"
       },
@@ -125,6 +127,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -388,7 +391,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -412,7 +414,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -451,14 +452,13 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -468,14 +468,13 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -485,14 +484,13 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -502,14 +500,13 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -519,14 +516,13 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -536,14 +532,13 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -553,14 +548,13 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -570,14 +564,13 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -587,14 +580,13 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -604,14 +596,13 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -621,14 +612,13 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -638,14 +628,13 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -655,14 +644,13 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -672,14 +660,13 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -689,14 +676,13 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -706,14 +692,13 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -723,14 +708,13 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -740,14 +724,13 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -757,14 +740,13 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -774,14 +756,13 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -791,14 +772,13 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -808,14 +788,13 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -825,14 +804,13 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -842,14 +820,13 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -859,14 +836,13 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -876,14 +852,13 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -3312,7 +3287,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.84.0.tgz",
       "integrity": "sha512-byMqYBvb91sx2jcZsdp0qLpmd4Dioe80e4OU/UexXftCkpTcgrkoENXHf5dO8FCSai8SgNeq16BKg10QiDI6xg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.84.0",
         "@supabase/functions-js": "2.84.0",
@@ -3615,6 +3589,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3635,6 +3610,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3694,6 +3670,19 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3710,7 +3699,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3894,7 +3884,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
       "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3905,7 +3894,6 @@
       "integrity": "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3983,7 +3971,6 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -4656,7 +4643,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5761,7 +5747,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.3.3",
@@ -6018,12 +6005,11 @@
       "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6031,32 +6017,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -6078,7 +6064,6 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6253,7 +6238,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8124,7 +8108,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -8198,7 +8181,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -8610,6 +8592,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9754,7 +9737,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
       "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
@@ -10286,6 +10268,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10301,6 +10284,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10313,7 +10297,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -10383,7 +10368,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10393,7 +10377,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10405,8 +10388,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -10439,7 +10421,6 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -10580,8 +10561,7 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "peer": true
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -11874,7 +11854,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12151,7 +12130,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12471,25 +12449,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -12498,14 +12474,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
         "jiti": ">=1.21.0",
-        "less": "^4.0.0",
+        "less": "*",
         "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -12613,7 +12589,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12627,7 +12602,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/lm-compass/package.json
+++ b/lm-compass/package.json
@@ -53,10 +53,11 @@
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^6.9.1",
-    "@testing-library/react": "^16.3.0",
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/papaparse": "^5.5.2",
     "@types/react": "^19",
@@ -68,6 +69,7 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5",
+    "vite": "^6.4.1",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4"
   },

--- a/lm-compass/vitest.config.mts
+++ b/lm-compass/vitest.config.mts
@@ -3,6 +3,9 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
+  esbuild: {
+    jsx: "automatic",
+  },
   test: {
     environment: "jsdom",
     passWithNoTests: true,

--- a/lm-compass/vitest.setup.ts
+++ b/lm-compass/vitest.setup.ts
@@ -2,6 +2,12 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
+globalThis.ResizeObserver ??= class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof globalThis.ResizeObserver;
+
 afterEach(() => {
   cleanup();
 });


### PR DESCRIPTION
Addresses #199 

Add front-end unit tests for PromptInput and SettingsDialog

**Summary**
- Added 32 unit tests for PromptInputComponent covering input validation, API call correctness, HTTP error handling, streaming response parsing, request cancellation, loading state lifecycle, and UI rendering
- Added 16 unit tests for SettingsDialog covering API key format validation, successful/failed save flows, loading states, error clearing, and form state management on close
- Installed @testing-library/user-event for simulating user interactions
- Pinned vite@^6 to fix Vitest 3 / Vite 7 ESM compatibility issue
- Added ResizeObserver polyfill to vitest.setup.ts for Radix UI components in jsdom
- Renamed vitest.config.ts to vitest.config.mts to resolve ESM module loading errors
- Added esbuild: { jsx: "automatic" } to Vitest config for JSX transform support in test files
