### PR TITLE
Quick bug fix for the theme selector

### DIFF
--- a/lm-compass/hooks/use-theme.ts
+++ b/lm-compass/hooks/use-theme.ts
@@ -4,11 +4,11 @@ import { useTheme as useNextTheme } from "next-themes";
 import { useEffect, useState } from "react";
 
 export function useTheme() {
-  const { theme, setTheme } = useNextTheme();
+  const { setTheme, resolvedTheme } = useNextTheme();
   const [mounted, setMounted] = useState(false);
 
-  // Only allow "light" or "dark", no "system"
-  const currentTheme = theme === "dark" ? "dark" : "light";
+  // Use resolvedTheme so "system" (default) still matches the real appearance (OS light/dark).
+  const currentTheme = resolvedTheme === "dark" ? "dark" : "light";
 
   useEffect(() => {
     setMounted(true);


### PR DESCRIPTION
As the title suggests, this PR will fix a bug @sohaibahmed7 noticed in the theme selector. "f you start a brand new session and your system defaults to dark mode, you have to press the toggle light/dark mode button twice for it to work... By default the button is on light mode so the button thinks ur going from light -> dark when you actually should be going dark -> light"

This PR aims to fix this bug